### PR TITLE
Fix: Correct path to db module in server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ app.use(express.urlencoded({extended: true}))
 
 app.use(session({ resave: true ,secret: '123456' , saveUninitialized: true}));
 
-require('./Models/db')();
+require('./models/db')();
 //the engine
 app.set('view engine', 'ejs');
 //Public folders


### PR DESCRIPTION
Changed the require statement in server.js to use the correct lowercase 'models' directory name instead of 'Models'. This resolves the 'MODULE_NOT_FOUND' error for './Models/db'.